### PR TITLE
Dodanie kraju i kodu kraju do edytora kontrahenta oraz eksportu KSeF

### DIFF
--- a/DB/Faktura.cs
+++ b/DB/Faktura.cs
@@ -423,7 +423,7 @@ public class Faktura : Rekord<Faktura>
 		SprzedawcaRef = kontrahent;
 		NIPSprzedawcy = kontrahent.NIP;
 		NazwaSprzedawcy = kontrahent.PelnaNazwaLubNazwa;
-		DaneSprzedawcy = kontrahent.AdresRejestrowy;
+		DaneSprzedawcy = kontrahent.AdresRejestrowyZKrajem;
 		RachunekBankowy = kontrahent.RachunekBankowy;
 		NazwaBanku = kontrahent.NazwaBanku;
 		if (CzySprzedaz)
@@ -442,7 +442,7 @@ public class Faktura : Rekord<Faktura>
 		NabywcaRef = kontrahent;
 		NIPNabywcy = kontrahent.NIP;
 		NazwaNabywcy = kontrahent.PelnaNazwaLubNazwa;
-		DaneNabywcy = kontrahent.AdresRejestrowy;
+		DaneNabywcy = kontrahent.AdresRejestrowyZKrajem;
 		CzyTP = kontrahent.CzyTP;
 		if (CzySprzedaz)
 		{

--- a/DB/Kontrahent.cs
+++ b/DB/Kontrahent.cs
@@ -8,6 +8,7 @@ public class Kontrahent : Rekord<Kontrahent>
 	public string AdresRejestrowy { get; set; } = "";
 	public string AdresKorespondencyjny { get; set; } = "";
 	public string Kraj { get; set; } = "";
+	public string KodKraju { get; set; } = "PL";
 	public string RachunekBankowy { get; set; } = "";
 	public string NazwaBanku { get; set; } = "";
 	public string Telefon { get; set; } = "";
@@ -47,6 +48,7 @@ public class Kontrahent : Rekord<Kontrahent>
 		|| CzyPasuje(AdresRejestrowy, fraza)
 		|| CzyPasuje(AdresKorespondencyjny, fraza)
 		|| CzyPasuje(Kraj, fraza)
+		|| CzyPasuje(KodKraju, fraza)
 		|| CzyPasuje(RachunekBankowy, fraza)
 		|| CzyPasuje(Telefon, fraza)
 		|| CzyPasuje(EMail, fraza)

--- a/DB/Kontrahent.cs
+++ b/DB/Kontrahent.cs
@@ -7,6 +7,7 @@ public class Kontrahent : Rekord<Kontrahent>
 	public string NIP { get; set; } = "";
 	public string AdresRejestrowy { get; set; } = "";
 	public string AdresKorespondencyjny { get; set; } = "";
+	public string Kraj { get; set; } = "";
 	public string RachunekBankowy { get; set; } = "";
 	public string NazwaBanku { get; set; } = "";
 	public string Telefon { get; set; } = "";
@@ -35,6 +36,7 @@ public class Kontrahent : Rekord<Kontrahent>
 	public Waluta? DomyslnaWaluta { get; set; }
 
 	public string AdresRejestrowyFmt => AdresRejestrowy.JakoJednaLinia();
+	public string AdresRejestrowyZKrajem => String.IsNullOrWhiteSpace(Kraj) ? AdresRejestrowy : (AdresRejestrowy + "\r\n" + Kraj).Trim();
 	public string PelnaNazwaLubNazwa => String.IsNullOrEmpty(PelnaNazwa) ? Nazwa : PelnaNazwa;
 
 	public override bool CzyPasuje(string fraza)
@@ -44,6 +46,7 @@ public class Kontrahent : Rekord<Kontrahent>
 		|| CzyPasuje(NIP, fraza)
 		|| CzyPasuje(AdresRejestrowy, fraza)
 		|| CzyPasuje(AdresKorespondencyjny, fraza)
+		|| CzyPasuje(Kraj, fraza)
 		|| CzyPasuje(RachunekBankowy, fraza)
 		|| CzyPasuje(Telefon, fraza)
 		|| CzyPasuje(EMail, fraza)

--- a/DB/Migrations-SqlServer/20260402090000_KontrahentKraj.cs
+++ b/DB/Migrations-SqlServer/20260402090000_KontrahentKraj.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProFak.DB.MigrationsSqlServer
+{
+    /// <inheritdoc />
+    public partial class KontrahentKraj : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Kraj",
+                table: "Kontrahent",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Kraj",
+                table: "Kontrahent");
+        }
+    }
+}

--- a/DB/Migrations-SqlServer/20260402103000_KontrahentKodKraju.cs
+++ b/DB/Migrations-SqlServer/20260402103000_KontrahentKodKraju.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProFak.DB.MigrationsSqlServer
+{
+    /// <inheritdoc />
+    public partial class KontrahentKodKraju : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "KodKraju",
+                table: "Kontrahent",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "PL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KodKraju",
+                table: "Kontrahent");
+        }
+    }
+}

--- a/DB/Migrations-SqlServer/BazaSqlServerModelSnapshot.cs
+++ b/DB/Migrations-SqlServer/BazaSqlServerModelSnapshot.cs
@@ -633,6 +633,12 @@ namespace ProFak.DB.MigrationsSqlServer
                         .HasColumnType("nvarchar(max)")
                         .HasDefaultValue("");
 
+                    b.Property<string>("Kraj")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("nvarchar(max)")
+                        .HasDefaultValue("");
+
                     b.Property<string>("NIP")
                         .IsRequired()
                         .ValueGeneratedOnAdd()

--- a/DB/Migrations-SqlServer/BazaSqlServerModelSnapshot.cs
+++ b/DB/Migrations-SqlServer/BazaSqlServerModelSnapshot.cs
@@ -639,6 +639,12 @@ namespace ProFak.DB.MigrationsSqlServer
                         .HasColumnType("nvarchar(max)")
                         .HasDefaultValue("");
 
+                    b.Property<string>("KodKraju")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("nvarchar(max)")
+                        .HasDefaultValue("PL");
+
                     b.Property<string>("NIP")
                         .IsRequired()
                         .ValueGeneratedOnAdd()

--- a/DB/Migrations/20260402090000_KontrahentKraj.cs
+++ b/DB/Migrations/20260402090000_KontrahentKraj.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProFak.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class KontrahentKraj : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Kraj",
+                table: "Kontrahent",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Kraj",
+                table: "Kontrahent");
+        }
+    }
+}

--- a/DB/Migrations/20260402103000_KontrahentKodKraju.cs
+++ b/DB/Migrations/20260402103000_KontrahentKodKraju.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProFak.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class KontrahentKodKraju : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "KodKraju",
+                table: "Kontrahent",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "PL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KodKraju",
+                table: "Kontrahent");
+        }
+    }
+}

--- a/DB/Migrations/ProFakContextModelSnapshot.cs
+++ b/DB/Migrations/ProFakContextModelSnapshot.cs
@@ -625,6 +625,12 @@ namespace ProFak.DB.Migrations
                         .HasColumnType("TEXT")
                         .HasDefaultValue("");
 
+                    b.Property<string>("KodKraju")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT")
+                        .HasDefaultValue("PL");
+
                     b.Property<string>("NIP")
                         .IsRequired()
                         .ValueGeneratedOnAdd()

--- a/DB/Migrations/ProFakContextModelSnapshot.cs
+++ b/DB/Migrations/ProFakContextModelSnapshot.cs
@@ -619,6 +619,12 @@ namespace ProFak.DB.Migrations
                         .HasColumnType("TEXT")
                         .HasDefaultValue("");
 
+                    b.Property<string>("Kraj")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT")
+                        .HasDefaultValue("");
+
                     b.Property<string>("NIP")
                         .IsRequired()
                         .ValueGeneratedOnAdd()

--- a/DB/Model/KontrahentBuilder.cs
+++ b/DB/Model/KontrahentBuilder.cs
@@ -17,6 +17,7 @@ class KontrahentBuilder
 		builder.Property(e => e.NIP).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.AdresRejestrowy).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.AdresKorespondencyjny).HasDefaultValue("").IsRequired();
+		builder.Property(e => e.Kraj).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.RachunekBankowy).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.NazwaBanku).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.Telefon).HasDefaultValue("").IsRequired();

--- a/DB/Model/KontrahentBuilder.cs
+++ b/DB/Model/KontrahentBuilder.cs
@@ -18,6 +18,7 @@ class KontrahentBuilder
 		builder.Property(e => e.AdresRejestrowy).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.AdresKorespondencyjny).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.Kraj).HasDefaultValue("").IsRequired();
+		builder.Property(e => e.KodKraju).HasDefaultValue("PL").IsRequired();
 		builder.Property(e => e.RachunekBankowy).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.NazwaBanku).HasDefaultValue("").IsRequired();
 		builder.Property(e => e.Telefon).HasDefaultValue("").IsRequired();

--- a/IO/FA_2/Generator.cs
+++ b/IO/FA_2/Generator.cs
@@ -12,6 +12,9 @@ namespace ProFak.IO.FA_2;
 
 public class Generator
 {
+	private static TKodKraju KodKrajuKSeF(string? kodKraju)
+		=> Enum.TryParse<TKodKraju>((kodKraju ?? "").Trim().ToUpperInvariant(), out var wynik) ? wynik : TKodKraju.PL;
+
 	public static string ZbudujXML(Baza baza, Ref<DBFaktura> dbFakturaRef)
 	{
 		var dbFaktura = baza.Faktury
@@ -60,11 +63,11 @@ public class Generator
 		ksefFaktura.Podmiot1.DaneIdentyfikacyjne.NIP = dbFaktura.NIPSprzedawcy;
 		ksefFaktura.Podmiot1.DaneIdentyfikacyjne.Nazwa = dbFaktura.NazwaSprzedawcy;
 		ksefFaktura.Podmiot1.Adres = new TAdres();
-		ksefFaktura.Podmiot1.Adres.KodKraju = TKodKraju.PL;
+		ksefFaktura.Podmiot1.Adres.KodKraju = KodKrajuKSeF(dbFaktura.Sprzedawca?.KodKraju);
 		ksefFaktura.Podmiot1.Adres.AdresL1 = dbFaktura.DaneSprzedawcy.JakoDwieLinie().linia1;
 		ksefFaktura.Podmiot1.Adres.AdresL2 = dbFaktura.DaneSprzedawcy.JakoDwieLinie().linia2;
 		ksefFaktura.Podmiot1.AdresKoresp = new FakturaPodmiot1AdresKoresp();
-		ksefFaktura.Podmiot1.AdresKoresp.KodKraju = TKodKraju.PL;
+		ksefFaktura.Podmiot1.AdresKoresp.KodKraju = KodKrajuKSeF(dbFaktura.Sprzedawca?.KodKraju);
 		ksefFaktura.Podmiot1.AdresKoresp.AdresL1 = dbFaktura.Sprzedawca.AdresKorespondencyjny.JakoDwieLinie().linia1;
 		ksefFaktura.Podmiot1.AdresKoresp.AdresL2 = dbFaktura.Sprzedawca.AdresKorespondencyjny.JakoDwieLinie().linia2;
 		ksefFaktura.Podmiot1.DaneKontaktowe.Add(new FakturaPodmiot1DaneKontaktowe { Email = String.IsNullOrWhiteSpace(dbFaktura.Sprzedawca.EMail) ? null : dbFaktura.Sprzedawca.EMail, Telefon = String.IsNullOrWhiteSpace(dbFaktura.Sprzedawca.Telefon) ? null : dbFaktura.Sprzedawca.Telefon });
@@ -80,7 +83,7 @@ public class Generator
 		}
 		ksefFaktura.Podmiot2.DaneIdentyfikacyjne.Nazwa = dbFaktura.NazwaNabywcy;
 		ksefFaktura.Podmiot2.Adres = new TAdres();
-		ksefFaktura.Podmiot2.Adres.KodKraju = TKodKraju.PL;
+		ksefFaktura.Podmiot2.Adres.KodKraju = KodKrajuKSeF(dbFaktura.Nabywca?.KodKraju);
 		ksefFaktura.Podmiot2.Adres.AdresL1 = dbFaktura.DaneNabywcy.JakoDwieLinie().linia1;
 		ksefFaktura.Podmiot2.Adres.AdresL2 = dbFaktura.DaneNabywcy.JakoDwieLinie().linia2;
 		ksefFaktura.Podmiot2.IDNabywcy = dbFaktura.NabywcaRef.Id.ToString();
@@ -260,6 +263,7 @@ public class Generator
 			}
 
 			if (ksefFaktura.Podmiot1.Adres != null) dbFaktura.Sprzedawca.AdresRejestrowy = dbFaktura.DaneSprzedawcy = ksefFaktura.Podmiot1.Adres.AdresL1 + "\r\n" + ksefFaktura.Podmiot1.Adres.AdresL2;
+			if (ksefFaktura.Podmiot1.Adres != null) dbFaktura.Sprzedawca.KodKraju = ksefFaktura.Podmiot1.Adres.KodKraju.ToString();
 			if (ksefFaktura.Podmiot1.AdresKoresp != null) dbFaktura.Sprzedawca.AdresKorespondencyjny = ksefFaktura.Podmiot1.AdresKoresp.AdresL1 + "\r\n" + ksefFaktura.Podmiot1.AdresKoresp.AdresL2;
 			if (ksefFaktura.Podmiot1.DaneKontaktowe != null && ksefFaktura.Podmiot1.DaneKontaktowe.Count > 0)
 			{
@@ -277,6 +281,7 @@ public class Generator
 			}
 
 			if (ksefFaktura.Podmiot2.Adres != null) dbFaktura.Nabywca.AdresRejestrowy = ksefFaktura.Podmiot2.Adres.AdresL1 + "\r\n" + ksefFaktura.Podmiot2.Adres.AdresL2;
+			if (ksefFaktura.Podmiot2.Adres != null) dbFaktura.Nabywca.KodKraju = ksefFaktura.Podmiot2.Adres.KodKraju.ToString();
 			if (ksefFaktura.Podmiot2.AdresKoresp != null) dbFaktura.Nabywca.AdresKorespondencyjny = ksefFaktura.Podmiot2.AdresKoresp.AdresL1 + "\r\n" + ksefFaktura.Podmiot2.AdresKoresp.AdresL2;
 			if (ksefFaktura.Podmiot2.DaneKontaktowe != null && ksefFaktura.Podmiot2.DaneKontaktowe.Count > 0)
 			{

--- a/IO/FA_3/Generator.cs
+++ b/IO/FA_3/Generator.cs
@@ -12,6 +12,9 @@ namespace ProFak.IO.FA_3;
 
 public class Generator
 {
+	private static TKodKraju KodKrajuKSeF(string? kodKraju)
+		=> Enum.TryParse<TKodKraju>((kodKraju ?? "").Trim().ToUpperInvariant(), out var wynik) ? wynik : TKodKraju.PL;
+
 	public static string ZbudujXML(Baza baza, Ref<DBFaktura> dbFakturaRef)
 	{
 		var dbFaktura = baza.Faktury
@@ -51,11 +54,11 @@ public class Generator
 		return dbFaktura;
 	}
 
-	private static T ZbudujAdres<T>(string adres) where T : TAdres, new()
+	private static T ZbudujAdres<T>(string adres, string? kodKraju) where T : TAdres, new()
 	{
 		var linie = adres.JakoDwieLinie();
 		var ksefAdres = new T();
-		ksefAdres.KodKraju = TKodKraju.PL;
+		ksefAdres.KodKraju = KodKrajuKSeF(kodKraju);
 		if (!String.IsNullOrWhiteSpace(linie.linia1)) ksefAdres.AdresL1 = linie.linia1;
 		if (!String.IsNullOrWhiteSpace(linie.linia2)) ksefAdres.AdresL2 = linie.linia2;
 		return ksefAdres;
@@ -77,8 +80,8 @@ public class Generator
 		ksefFaktura.Podmiot1.DaneIdentyfikacyjne = new TPodmiot1();
 		ksefFaktura.Podmiot1.DaneIdentyfikacyjne.NIP = dbFaktura.NIPSprzedawcy.Replace("-", "");
 		ksefFaktura.Podmiot1.DaneIdentyfikacyjne.Nazwa = dbFaktura.NazwaSprzedawcy;
-		ksefFaktura.Podmiot1.Adres = ZbudujAdres<TAdres>(dbFaktura.DaneSprzedawcy);
-		if (!String.IsNullOrEmpty(dbFaktura.Sprzedawca.AdresKorespondencyjny) && dbFaktura.Sprzedawca.AdresKorespondencyjny != dbFaktura.DaneSprzedawcy) ksefFaktura.Podmiot1.AdresKoresp = ZbudujAdres<FakturaPodmiot1AdresKoresp>(dbFaktura.Sprzedawca.AdresKorespondencyjny);
+		ksefFaktura.Podmiot1.Adres = ZbudujAdres<TAdres>(dbFaktura.DaneSprzedawcy, dbFaktura.Sprzedawca.KodKraju);
+		if (!String.IsNullOrEmpty(dbFaktura.Sprzedawca.AdresKorespondencyjny) && dbFaktura.Sprzedawca.AdresKorespondencyjny != dbFaktura.DaneSprzedawcy) ksefFaktura.Podmiot1.AdresKoresp = ZbudujAdres<FakturaPodmiot1AdresKoresp>(dbFaktura.Sprzedawca.AdresKorespondencyjny, dbFaktura.Sprzedawca.KodKraju);
 		ksefFaktura.Podmiot1.DaneKontaktowe.Add(new FakturaPodmiot1DaneKontaktowe { Email = String.IsNullOrWhiteSpace(dbFaktura.Sprzedawca.EMail) ? null : dbFaktura.Sprzedawca.EMail, Telefon = String.IsNullOrWhiteSpace(dbFaktura.Sprzedawca.Telefon) ? null : dbFaktura.Sprzedawca.Telefon });
 		ksefFaktura.Podmiot2 = new FakturaPodmiot2();
 		ksefFaktura.Podmiot2.DaneIdentyfikacyjne = new TPodmiot2();
@@ -91,7 +94,7 @@ public class Generator
 			ksefFaktura.Podmiot2.DaneIdentyfikacyjne.NIP = dbFaktura.NIPNabywcy.Replace("-", "");
 		}
 		ksefFaktura.Podmiot2.DaneIdentyfikacyjne.Nazwa = dbFaktura.NazwaNabywcy;
-		ksefFaktura.Podmiot2.Adres = ZbudujAdres<TAdres>(dbFaktura.DaneNabywcy);
+		ksefFaktura.Podmiot2.Adres = ZbudujAdres<TAdres>(dbFaktura.DaneNabywcy, dbFaktura.Nabywca.KodKraju);
 		ksefFaktura.Podmiot2.GV = FakturaPodmiot2GV.Item2;
 		ksefFaktura.Podmiot2.JST = FakturaPodmiot2JST.Item2;
 		ksefFaktura.Fa = new FakturaFa();
@@ -199,7 +202,7 @@ public class Generator
 				ksefFaktura.Fa.Podmiot1K.DaneIdentyfikacyjne = new TPodmiot1();
 				ksefFaktura.Fa.Podmiot1K.DaneIdentyfikacyjne.Nazwa = dbFaktura.FakturaKorygowana.NazwaSprzedawcy;
 				ksefFaktura.Fa.Podmiot1K.DaneIdentyfikacyjne.NIP = dbFaktura.FakturaKorygowana.NIPSprzedawcy.Replace("-", "");
-				ksefFaktura.Fa.Podmiot1K.Adres = ZbudujAdres<TAdres>(dbFaktura.FakturaKorygowana.DaneSprzedawcy);
+				ksefFaktura.Fa.Podmiot1K.Adres = ZbudujAdres<TAdres>(dbFaktura.FakturaKorygowana.DaneSprzedawcy, "PL");
 			}
 
 			if (dbFaktura.FakturaKorygowana.NazwaNabywcy != dbFaktura.NazwaNabywcy || dbFaktura.FakturaKorygowana.DaneNabywcy != dbFaktura.DaneNabywcy)
@@ -208,7 +211,7 @@ public class Generator
 				podmiot2k.DaneIdentyfikacyjne = new TPodmiot2();
 				podmiot2k.DaneIdentyfikacyjne.Nazwa = dbFaktura.FakturaKorygowana.NazwaNabywcy;
 				podmiot2k.DaneIdentyfikacyjne = ksefFaktura.Podmiot2.DaneIdentyfikacyjne;
-				podmiot2k.Adres = ZbudujAdres<TAdres>(dbFaktura.FakturaKorygowana.DaneNabywcy);
+				podmiot2k.Adres = ZbudujAdres<TAdres>(dbFaktura.FakturaKorygowana.DaneNabywcy, "PL");
 				ksefFaktura.Fa.Podmiot2K.Add(podmiot2k);
 			}
 		}
@@ -234,7 +237,7 @@ public class Generator
 			if (!String.IsNullOrEmpty(dbPodmiot3.NIP)) ksefPodmiot3.DaneIdentyfikacyjne.NIP = dbPodmiot3.NIP;
 			if (!String.IsNullOrEmpty(dbPodmiot3.VatUE)) ksefPodmiot3.DaneIdentyfikacyjne.NrVatUE = dbPodmiot3.VatUE;
 			if (!String.IsNullOrEmpty(dbPodmiot3.IDwew)) ksefPodmiot3.DaneIdentyfikacyjne.IDWew = dbPodmiot3.IDwew;
-			if (!String.IsNullOrEmpty(dbPodmiot3.Adres)) ksefPodmiot3.Adres = ZbudujAdres<TAdres>(dbPodmiot3.Adres);
+			if (!String.IsNullOrEmpty(dbPodmiot3.Adres)) ksefPodmiot3.Adres = ZbudujAdres<TAdres>(dbPodmiot3.Adres, "PL");
 			dbPodmiot3.Udzial = ksefPodmiot3.Udzial;
 
 			ksefFaktura.Podmiot3.Add(ksefPodmiot3);
@@ -373,6 +376,7 @@ public class Generator
 			}
 
 			if (ksefFaktura.Podmiot1.Adres != null) dbFaktura.Sprzedawca.AdresRejestrowy = dbFaktura.DaneSprzedawcy = ksefFaktura.Podmiot1.Adres.AdresL1 + "\r\n" + ksefFaktura.Podmiot1.Adres.AdresL2;
+			if (ksefFaktura.Podmiot1.Adres != null) dbFaktura.Sprzedawca.KodKraju = ksefFaktura.Podmiot1.Adres.KodKraju.ToString();
 			if (ksefFaktura.Podmiot1.AdresKoresp != null) dbFaktura.Sprzedawca.AdresKorespondencyjny = ksefFaktura.Podmiot1.AdresKoresp.AdresL1 + "\r\n" + ksefFaktura.Podmiot1.AdresKoresp.AdresL2;
 			if (ksefFaktura.Podmiot1.DaneKontaktowe != null && ksefFaktura.Podmiot1.DaneKontaktowe.Count > 0)
 			{
@@ -390,6 +394,7 @@ public class Generator
 			}
 
 			if (ksefFaktura.Podmiot2.Adres != null) dbFaktura.Nabywca.AdresRejestrowy = dbFaktura.DaneNabywcy = ksefFaktura.Podmiot2.Adres.AdresL1 + "\r\n" + ksefFaktura.Podmiot2.Adres.AdresL2;
+			if (ksefFaktura.Podmiot2.Adres != null) dbFaktura.Nabywca.KodKraju = ksefFaktura.Podmiot2.Adres.KodKraju.ToString();
 			if (ksefFaktura.Podmiot2.AdresKoresp != null) dbFaktura.Nabywca.AdresKorespondencyjny = ksefFaktura.Podmiot2.AdresKoresp.AdresL1 + "\r\n" + ksefFaktura.Podmiot2.AdresKoresp.AdresL2;
 			if (ksefFaktura.Podmiot2.DaneKontaktowe != null && ksefFaktura.Podmiot2.DaneKontaktowe.Count > 0)
 			{

--- a/IO/GUS.cs
+++ b/IO/GUS.cs
@@ -59,6 +59,7 @@ public class GUS
 		kontrahent.PelnaNazwa = nazwa ?? "";
 		kontrahent.AdresRejestrowy = ulica?.Replace("&#8209;", "") + "\r\n" + kodpocztowy + " " + miejscowosc;
 		kontrahent.AdresKorespondencyjny = kontrahent.AdresRejestrowy;
+		kontrahent.Kraj = "Polska";
 	}
 
 	private static string DekodujGUS(string wejscie)

--- a/IO/GUS.cs
+++ b/IO/GUS.cs
@@ -60,6 +60,7 @@ public class GUS
 		kontrahent.AdresRejestrowy = ulica?.Replace("&#8209;", "") + "\r\n" + kodpocztowy + " " + miejscowosc;
 		kontrahent.AdresKorespondencyjny = kontrahent.AdresRejestrowy;
 		kontrahent.Kraj = "Polska";
+		kontrahent.KodKraju = "PL";
 	}
 
 	private static string DekodujGUS(string wejscie)

--- a/UI/Kontrahenci/KontrahentEdytor.Designer.cs
+++ b/UI/Kontrahenci/KontrahentEdytor.Designer.cs
@@ -38,6 +38,7 @@ partial class KontrahentEdytor
 		textBoxNIP = new TextBox();
 		textBoxAdresRejestrowy = new TextBox();
 		textBoxAdresKorespondencyjny = new TextBox();
+		textBoxKraj = new TextBox();
 		textBoxTelefon = new TextBox();
 		textBoxEMail = new TextBox();
 		textBoxRachunekBankowy = new TextBox();
@@ -46,6 +47,7 @@ partial class KontrahentEdytor
 		label6 = new Label();
 		label7 = new Label();
 		label8 = new Label();
+		label17 = new Label();
 		comboBoxStan = new ComboBox();
 		label9 = new Label();
 		checkBoxTP = new CheckBox();
@@ -142,27 +144,29 @@ partial class KontrahentEdytor
 		tableLayoutPanel1.Controls.Add(textBoxNIP, 1, 1);
 		tableLayoutPanel1.Controls.Add(textBoxAdresRejestrowy, 1, 2);
 		tableLayoutPanel1.Controls.Add(textBoxAdresKorespondencyjny, 1, 3);
-		tableLayoutPanel1.Controls.Add(textBoxTelefon, 1, 4);
-		tableLayoutPanel1.Controls.Add(textBoxEMail, 1, 5);
-		tableLayoutPanel1.Controls.Add(textBoxRachunekBankowy, 1, 6);
+		tableLayoutPanel1.Controls.Add(textBoxKraj, 1, 4);
+		tableLayoutPanel1.Controls.Add(textBoxTelefon, 1, 5);
+		tableLayoutPanel1.Controls.Add(textBoxEMail, 1, 6);
+		tableLayoutPanel1.Controls.Add(textBoxRachunekBankowy, 1, 7);
 		tableLayoutPanel1.Controls.Add(label4, 0, 2);
 		tableLayoutPanel1.Controls.Add(label5, 0, 3);
-		tableLayoutPanel1.Controls.Add(label6, 0, 4);
-		tableLayoutPanel1.Controls.Add(label7, 0, 5);
-		tableLayoutPanel1.Controls.Add(label8, 0, 6);
-		tableLayoutPanel1.Controls.Add(comboBoxStan, 1, 7);
-		tableLayoutPanel1.Controls.Add(label9, 0, 7);
-		tableLayoutPanel1.Controls.Add(checkBoxTP, 1, 10);
-		tableLayoutPanel1.Controls.Add(buttonSprawdzMF, 3, 6);
+		tableLayoutPanel1.Controls.Add(label17, 0, 4);
+		tableLayoutPanel1.Controls.Add(label6, 0, 5);
+		tableLayoutPanel1.Controls.Add(label7, 0, 6);
+		tableLayoutPanel1.Controls.Add(label8, 0, 7);
+		tableLayoutPanel1.Controls.Add(comboBoxStan, 1, 8);
+		tableLayoutPanel1.Controls.Add(label9, 0, 8);
+		tableLayoutPanel1.Controls.Add(checkBoxTP, 1, 11);
+		tableLayoutPanel1.Controls.Add(buttonSprawdzMF, 3, 7);
 		tableLayoutPanel1.Controls.Add(buttonPobierzGUS, 3, 1);
-		tableLayoutPanel1.Controls.Add(labelSposobPlatnosci, 0, 9);
-		tableLayoutPanel1.Controls.Add(comboBoxSposobPlatnosci, 1, 9);
-		tableLayoutPanel1.Controls.Add(buttonSposobPlatnosci, 3, 9);
-		tableLayoutPanel1.Controls.Add(textBoxNazwaBanku, 2, 6);
-		tableLayoutPanel1.Controls.Add(label16, 0, 12);
-		tableLayoutPanel1.Controls.Add(buttonWaluta, 2, 12);
-		tableLayoutPanel1.Controls.Add(comboBoxWaluta, 1, 12);
-		tableLayoutPanel1.Controls.Add(checkBoxImportKSeF, 1, 11);
+		tableLayoutPanel1.Controls.Add(labelSposobPlatnosci, 0, 10);
+		tableLayoutPanel1.Controls.Add(comboBoxSposobPlatnosci, 1, 10);
+		tableLayoutPanel1.Controls.Add(buttonSposobPlatnosci, 3, 10);
+		tableLayoutPanel1.Controls.Add(textBoxNazwaBanku, 2, 7);
+		tableLayoutPanel1.Controls.Add(label16, 0, 13);
+		tableLayoutPanel1.Controls.Add(buttonWaluta, 2, 13);
+		tableLayoutPanel1.Controls.Add(comboBoxWaluta, 1, 13);
+		tableLayoutPanel1.Controls.Add(checkBoxImportKSeF, 1, 12);
 		tableLayoutPanel1.Dock = DockStyle.Fill;
 		tableLayoutPanel1.Location = new Point(3, 3);
 		tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -248,29 +252,38 @@ partial class KontrahentEdytor
 		// 
 		// textBoxTelefon
 		// 
+		textBoxKraj.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+		tableLayoutPanel1.SetColumnSpan(textBoxKraj, 3);
+		textBoxKraj.Location = new Point(146, 205);
+		textBoxKraj.Name = "textBoxKraj";
+		textBoxKraj.Size = new Size(631, 23);
+		textBoxKraj.TabIndex = 5;
+		// 
+		// textBoxTelefon
+		// 
 		textBoxTelefon.Anchor = AnchorStyles.Left | AnchorStyles.Right;
 		tableLayoutPanel1.SetColumnSpan(textBoxTelefon, 3);
-		textBoxTelefon.Location = new Point(146, 205);
+		textBoxTelefon.Location = new Point(146, 234);
 		textBoxTelefon.Name = "textBoxTelefon";
 		textBoxTelefon.Size = new Size(631, 23);
-		textBoxTelefon.TabIndex = 5;
+		textBoxTelefon.TabIndex = 6;
 		// 
 		// textBoxEMail
 		// 
 		textBoxEMail.Anchor = AnchorStyles.Left | AnchorStyles.Right;
 		tableLayoutPanel1.SetColumnSpan(textBoxEMail, 3);
-		textBoxEMail.Location = new Point(146, 234);
+		textBoxEMail.Location = new Point(146, 263);
 		textBoxEMail.Name = "textBoxEMail";
 		textBoxEMail.Size = new Size(631, 23);
-		textBoxEMail.TabIndex = 6;
+		textBoxEMail.TabIndex = 7;
 		// 
 		// textBoxRachunekBankowy
 		// 
 		textBoxRachunekBankowy.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-		textBoxRachunekBankowy.Location = new Point(146, 264);
+		textBoxRachunekBankowy.Location = new Point(146, 293);
 		textBoxRachunekBankowy.Name = "textBoxRachunekBankowy";
 		textBoxRachunekBankowy.Size = new Size(263, 23);
-		textBoxRachunekBankowy.TabIndex = 7;
+		textBoxRachunekBankowy.TabIndex = 8;
 		// 
 		// label4
 		// 
@@ -294,9 +307,19 @@ partial class KontrahentEdytor
 		// 
 		// label6
 		// 
+		label17.Anchor = AnchorStyles.Right;
+		label17.AutoSize = true;
+		label17.Location = new Point(110, 209);
+		label17.Name = "label17";
+		label17.Size = new Size(30, 15);
+		label17.TabIndex = 2;
+		label17.Text = "Kraj";
+		// 
+		// label6
+		// 
 		label6.Anchor = AnchorStyles.Right;
 		label6.AutoSize = true;
-		label6.Location = new Point(95, 209);
+		label6.Location = new Point(95, 238);
 		label6.Name = "label6";
 		label6.Size = new Size(45, 15);
 		label6.TabIndex = 2;
@@ -306,7 +329,7 @@ partial class KontrahentEdytor
 		// 
 		label7.Anchor = AnchorStyles.Right;
 		label7.AutoSize = true;
-		label7.Location = new Point(99, 238);
+		label7.Location = new Point(99, 267);
 		label7.Name = "label7";
 		label7.Size = new Size(41, 15);
 		label7.TabIndex = 2;
@@ -316,7 +339,7 @@ partial class KontrahentEdytor
 		// 
 		label8.Anchor = AnchorStyles.Right;
 		label8.AutoSize = true;
-		label8.Location = new Point(30, 268);
+		label8.Location = new Point(30, 297);
 		label8.Name = "label8";
 		label8.Size = new Size(110, 15);
 		label8.TabIndex = 2;
@@ -328,16 +351,16 @@ partial class KontrahentEdytor
 		tableLayoutPanel1.SetColumnSpan(comboBoxStan, 3);
 		comboBoxStan.DropDownStyle = ComboBoxStyle.DropDownList;
 		comboBoxStan.FormattingEnabled = true;
-		comboBoxStan.Location = new Point(146, 294);
+		comboBoxStan.Location = new Point(146, 323);
 		comboBoxStan.Name = "comboBoxStan";
 		comboBoxStan.Size = new Size(631, 23);
-		comboBoxStan.TabIndex = 10;
+		comboBoxStan.TabIndex = 11;
 		// 
 		// label9
 		// 
 		label9.Anchor = AnchorStyles.Right;
 		label9.AutoSize = true;
-		label9.Location = new Point(110, 298);
+		label9.Location = new Point(110, 327);
 		label9.Name = "label9";
 		label9.Size = new Size(30, 15);
 		label9.TabIndex = 2;
@@ -346,20 +369,20 @@ partial class KontrahentEdytor
 		// checkBoxTP
 		// 
 		checkBoxTP.AutoSize = true;
-		checkBoxTP.Location = new Point(146, 354);
+		checkBoxTP.Location = new Point(146, 383);
 		checkBoxTP.Name = "checkBoxTP";
 		checkBoxTP.Size = new Size(131, 19);
-		checkBoxTP.TabIndex = 13;
+		checkBoxTP.TabIndex = 14;
 		checkBoxTP.Text = "Podmiot powiązany";
 		checkBoxTP.UseVisualStyleBackColor = true;
 		// 
 		// buttonSprawdzMF
 		// 
 		buttonSprawdzMF.AutoSize = true;
-		buttonSprawdzMF.Location = new Point(617, 263);
+		buttonSprawdzMF.Location = new Point(617, 292);
 		buttonSprawdzMF.Name = "buttonSprawdzMF";
 		buttonSprawdzMF.Size = new Size(160, 25);
-		buttonSprawdzMF.TabIndex = 9;
+		buttonSprawdzMF.TabIndex = 10;
 		buttonSprawdzMF.Text = "Sprawdź na białej liście VAT";
 		buttonSprawdzMF.UseVisualStyleBackColor = true;
 		buttonSprawdzMF.Click += buttonSprawdzMF_Click;
@@ -379,7 +402,7 @@ partial class KontrahentEdytor
 		// 
 		labelSposobPlatnosci.Anchor = AnchorStyles.Right;
 		labelSposobPlatnosci.AutoSize = true;
-		labelSposobPlatnosci.Location = new Point(43, 328);
+		labelSposobPlatnosci.Location = new Point(43, 357);
 		labelSposobPlatnosci.Name = "labelSposobPlatnosci";
 		labelSposobPlatnosci.Size = new Size(97, 15);
 		labelSposobPlatnosci.TabIndex = 2;
@@ -391,18 +414,18 @@ partial class KontrahentEdytor
 		tableLayoutPanel1.SetColumnSpan(comboBoxSposobPlatnosci, 2);
 		comboBoxSposobPlatnosci.DropDownStyle = ComboBoxStyle.DropDownList;
 		comboBoxSposobPlatnosci.FormattingEnabled = true;
-		comboBoxSposobPlatnosci.Location = new Point(146, 324);
+		comboBoxSposobPlatnosci.Location = new Point(146, 353);
 		comboBoxSposobPlatnosci.Name = "comboBoxSposobPlatnosci";
 		comboBoxSposobPlatnosci.Size = new Size(465, 23);
-		comboBoxSposobPlatnosci.TabIndex = 11;
+		comboBoxSposobPlatnosci.TabIndex = 12;
 		// 
 		// buttonSposobPlatnosci
 		// 
 		buttonSposobPlatnosci.AutoSize = true;
-		buttonSposobPlatnosci.Location = new Point(617, 323);
+		buttonSposobPlatnosci.Location = new Point(617, 352);
 		buttonSposobPlatnosci.Name = "buttonSposobPlatnosci";
 		buttonSposobPlatnosci.Size = new Size(26, 25);
-		buttonSposobPlatnosci.TabIndex = 12;
+		buttonSposobPlatnosci.TabIndex = 13;
 		buttonSposobPlatnosci.Text = "...";
 		buttonSposobPlatnosci.UseVisualStyleBackColor = true;
 		buttonSposobPlatnosci.Click += buttonSprawdzMF_Click;
@@ -410,7 +433,7 @@ partial class KontrahentEdytor
 		// textBoxNazwaBanku
 		// 
 		textBoxNazwaBanku.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-		textBoxNazwaBanku.Location = new Point(415, 264);
+		textBoxNazwaBanku.Location = new Point(415, 293);
 		textBoxNazwaBanku.Name = "textBoxNazwaBanku";
 		textBoxNazwaBanku.PlaceholderText = "Nazwa banku";
 		textBoxNazwaBanku.Size = new Size(196, 23);
@@ -420,7 +443,7 @@ partial class KontrahentEdytor
 		// 
 		label16.Anchor = AnchorStyles.Right;
 		label16.AutoSize = true;
-		label16.Location = new Point(42, 409);
+		label16.Location = new Point(42, 438);
 		label16.Name = "label16";
 		label16.Size = new Size(98, 15);
 		label16.TabIndex = 14;
@@ -429,7 +452,7 @@ partial class KontrahentEdytor
 		// buttonWaluta
 		// 
 		buttonWaluta.AutoSize = true;
-		buttonWaluta.Location = new Point(415, 404);
+		buttonWaluta.Location = new Point(415, 433);
 		buttonWaluta.Name = "buttonWaluta";
 		buttonWaluta.Size = new Size(26, 25);
 		buttonWaluta.TabIndex = 16;
@@ -441,10 +464,10 @@ partial class KontrahentEdytor
 		comboBoxWaluta.Anchor = AnchorStyles.Left | AnchorStyles.Right;
 		comboBoxWaluta.DropDownStyle = ComboBoxStyle.DropDownList;
 		comboBoxWaluta.FormattingEnabled = true;
-		comboBoxWaluta.Location = new Point(146, 405);
+		comboBoxWaluta.Location = new Point(146, 434);
 		comboBoxWaluta.Name = "comboBoxWaluta";
 		comboBoxWaluta.Size = new Size(263, 23);
-		comboBoxWaluta.TabIndex = 15;
+		comboBoxWaluta.TabIndex = 16;
 		// 
 		// tabPage2
 		// 
@@ -796,10 +819,10 @@ partial class KontrahentEdytor
 		// 
 		checkBoxImportKSeF.AutoSize = true;
 		tableLayoutPanel1.SetColumnSpan(checkBoxImportKSeF, 2);
-		checkBoxImportKSeF.Location = new Point(146, 379);
+		checkBoxImportKSeF.Location = new Point(146, 408);
 		checkBoxImportKSeF.Name = "checkBoxImportKSeF";
 		checkBoxImportKSeF.Size = new Size(343, 19);
-		checkBoxImportKSeF.TabIndex = 13;
+		checkBoxImportKSeF.TabIndex = 15;
 		checkBoxImportKSeF.Text = "Pobrany z KSeF (ukryty przy ręcznym wprowadzaniu faktury)";
 		checkBoxImportKSeF.UseVisualStyleBackColor = true;
 		// 
@@ -846,6 +869,7 @@ partial class KontrahentEdytor
 	private System.Windows.Forms.TextBox textBoxNIP;
 	private System.Windows.Forms.TextBox textBoxAdresRejestrowy;
 	private System.Windows.Forms.TextBox textBoxAdresKorespondencyjny;
+	private System.Windows.Forms.TextBox textBoxKraj;
 	private System.Windows.Forms.TextBox textBoxTelefon;
 	private System.Windows.Forms.TextBox textBoxEMail;
 	private System.Windows.Forms.TextBox textBoxRachunekBankowy;
@@ -854,6 +878,7 @@ partial class KontrahentEdytor
 	private System.Windows.Forms.Label label6;
 	private System.Windows.Forms.Label label7;
 	private System.Windows.Forms.Label label8;
+	private System.Windows.Forms.Label label17;
 	private System.Windows.Forms.TextBox textBoxUwagiWewnetrzne;
 	private System.Windows.Forms.ComboBox comboBoxStan;
 	private System.Windows.Forms.Label label9;

--- a/UI/Kontrahenci/KontrahentEdytor.Designer.cs
+++ b/UI/Kontrahenci/KontrahentEdytor.Designer.cs
@@ -39,6 +39,7 @@ partial class KontrahentEdytor
 		textBoxAdresRejestrowy = new TextBox();
 		textBoxAdresKorespondencyjny = new TextBox();
 		textBoxKraj = new TextBox();
+		textBoxKodKraju = new TextBox();
 		textBoxTelefon = new TextBox();
 		textBoxEMail = new TextBox();
 		textBoxRachunekBankowy = new TextBox();
@@ -48,6 +49,7 @@ partial class KontrahentEdytor
 		label7 = new Label();
 		label8 = new Label();
 		label17 = new Label();
+		label18 = new Label();
 		comboBoxStan = new ComboBox();
 		label9 = new Label();
 		checkBoxTP = new CheckBox();
@@ -145,28 +147,30 @@ partial class KontrahentEdytor
 		tableLayoutPanel1.Controls.Add(textBoxAdresRejestrowy, 1, 2);
 		tableLayoutPanel1.Controls.Add(textBoxAdresKorespondencyjny, 1, 3);
 		tableLayoutPanel1.Controls.Add(textBoxKraj, 1, 4);
-		tableLayoutPanel1.Controls.Add(textBoxTelefon, 1, 5);
-		tableLayoutPanel1.Controls.Add(textBoxEMail, 1, 6);
-		tableLayoutPanel1.Controls.Add(textBoxRachunekBankowy, 1, 7);
+		tableLayoutPanel1.Controls.Add(textBoxKodKraju, 1, 5);
+		tableLayoutPanel1.Controls.Add(textBoxTelefon, 1, 6);
+		tableLayoutPanel1.Controls.Add(textBoxEMail, 1, 7);
+		tableLayoutPanel1.Controls.Add(textBoxRachunekBankowy, 1, 8);
 		tableLayoutPanel1.Controls.Add(label4, 0, 2);
 		tableLayoutPanel1.Controls.Add(label5, 0, 3);
 		tableLayoutPanel1.Controls.Add(label17, 0, 4);
-		tableLayoutPanel1.Controls.Add(label6, 0, 5);
-		tableLayoutPanel1.Controls.Add(label7, 0, 6);
-		tableLayoutPanel1.Controls.Add(label8, 0, 7);
-		tableLayoutPanel1.Controls.Add(comboBoxStan, 1, 8);
-		tableLayoutPanel1.Controls.Add(label9, 0, 8);
-		tableLayoutPanel1.Controls.Add(checkBoxTP, 1, 11);
-		tableLayoutPanel1.Controls.Add(buttonSprawdzMF, 3, 7);
+		tableLayoutPanel1.Controls.Add(label18, 0, 5);
+		tableLayoutPanel1.Controls.Add(label6, 0, 6);
+		tableLayoutPanel1.Controls.Add(label7, 0, 7);
+		tableLayoutPanel1.Controls.Add(label8, 0, 8);
+		tableLayoutPanel1.Controls.Add(comboBoxStan, 1, 9);
+		tableLayoutPanel1.Controls.Add(label9, 0, 9);
+		tableLayoutPanel1.Controls.Add(checkBoxTP, 1, 12);
+		tableLayoutPanel1.Controls.Add(buttonSprawdzMF, 3, 8);
 		tableLayoutPanel1.Controls.Add(buttonPobierzGUS, 3, 1);
-		tableLayoutPanel1.Controls.Add(labelSposobPlatnosci, 0, 10);
-		tableLayoutPanel1.Controls.Add(comboBoxSposobPlatnosci, 1, 10);
-		tableLayoutPanel1.Controls.Add(buttonSposobPlatnosci, 3, 10);
-		tableLayoutPanel1.Controls.Add(textBoxNazwaBanku, 2, 7);
-		tableLayoutPanel1.Controls.Add(label16, 0, 13);
-		tableLayoutPanel1.Controls.Add(buttonWaluta, 2, 13);
-		tableLayoutPanel1.Controls.Add(comboBoxWaluta, 1, 13);
-		tableLayoutPanel1.Controls.Add(checkBoxImportKSeF, 1, 12);
+		tableLayoutPanel1.Controls.Add(labelSposobPlatnosci, 0, 11);
+		tableLayoutPanel1.Controls.Add(comboBoxSposobPlatnosci, 1, 11);
+		tableLayoutPanel1.Controls.Add(buttonSposobPlatnosci, 3, 11);
+		tableLayoutPanel1.Controls.Add(textBoxNazwaBanku, 2, 8);
+		tableLayoutPanel1.Controls.Add(label16, 0, 14);
+		tableLayoutPanel1.Controls.Add(buttonWaluta, 2, 14);
+		tableLayoutPanel1.Controls.Add(comboBoxWaluta, 1, 14);
+		tableLayoutPanel1.Controls.Add(checkBoxImportKSeF, 1, 13);
 		tableLayoutPanel1.Dock = DockStyle.Fill;
 		tableLayoutPanel1.Location = new Point(3, 3);
 		tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -259,31 +263,41 @@ partial class KontrahentEdytor
 		textBoxKraj.Size = new Size(631, 23);
 		textBoxKraj.TabIndex = 5;
 		// 
+		// textBoxKodKraju
+		// 
+		textBoxKodKraju.Anchor = AnchorStyles.Left;
+		textBoxKodKraju.CharacterCasing = CharacterCasing.Upper;
+		textBoxKodKraju.Location = new Point(146, 234);
+		textBoxKodKraju.MaxLength = 2;
+		textBoxKodKraju.Name = "textBoxKodKraju";
+		textBoxKodKraju.Size = new Size(50, 23);
+		textBoxKodKraju.TabIndex = 6;
+		// 
 		// textBoxTelefon
 		// 
 		textBoxTelefon.Anchor = AnchorStyles.Left | AnchorStyles.Right;
 		tableLayoutPanel1.SetColumnSpan(textBoxTelefon, 3);
-		textBoxTelefon.Location = new Point(146, 234);
+		textBoxTelefon.Location = new Point(146, 263);
 		textBoxTelefon.Name = "textBoxTelefon";
 		textBoxTelefon.Size = new Size(631, 23);
-		textBoxTelefon.TabIndex = 6;
+		textBoxTelefon.TabIndex = 7;
 		// 
 		// textBoxEMail
 		// 
 		textBoxEMail.Anchor = AnchorStyles.Left | AnchorStyles.Right;
 		tableLayoutPanel1.SetColumnSpan(textBoxEMail, 3);
-		textBoxEMail.Location = new Point(146, 263);
+		textBoxEMail.Location = new Point(146, 292);
 		textBoxEMail.Name = "textBoxEMail";
 		textBoxEMail.Size = new Size(631, 23);
-		textBoxEMail.TabIndex = 7;
+		textBoxEMail.TabIndex = 8;
 		// 
 		// textBoxRachunekBankowy
 		// 
 		textBoxRachunekBankowy.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-		textBoxRachunekBankowy.Location = new Point(146, 293);
+		textBoxRachunekBankowy.Location = new Point(146, 322);
 		textBoxRachunekBankowy.Name = "textBoxRachunekBankowy";
 		textBoxRachunekBankowy.Size = new Size(263, 23);
-		textBoxRachunekBankowy.TabIndex = 8;
+		textBoxRachunekBankowy.TabIndex = 9;
 		// 
 		// label4
 		// 
@@ -315,11 +329,21 @@ partial class KontrahentEdytor
 		label17.TabIndex = 2;
 		label17.Text = "Kraj";
 		// 
+		// label18
+		// 
+		label18.Anchor = AnchorStyles.Right;
+		label18.AutoSize = true;
+		label18.Location = new Point(83, 238);
+		label18.Name = "label18";
+		label18.Size = new Size(57, 15);
+		label18.TabIndex = 2;
+		label18.Text = "Kod kraju";
+		// 
 		// label6
 		// 
 		label6.Anchor = AnchorStyles.Right;
 		label6.AutoSize = true;
-		label6.Location = new Point(95, 238);
+		label6.Location = new Point(95, 267);
 		label6.Name = "label6";
 		label6.Size = new Size(45, 15);
 		label6.TabIndex = 2;
@@ -329,7 +353,7 @@ partial class KontrahentEdytor
 		// 
 		label7.Anchor = AnchorStyles.Right;
 		label7.AutoSize = true;
-		label7.Location = new Point(99, 267);
+		label7.Location = new Point(99, 296);
 		label7.Name = "label7";
 		label7.Size = new Size(41, 15);
 		label7.TabIndex = 2;
@@ -339,7 +363,7 @@ partial class KontrahentEdytor
 		// 
 		label8.Anchor = AnchorStyles.Right;
 		label8.AutoSize = true;
-		label8.Location = new Point(30, 297);
+		label8.Location = new Point(30, 326);
 		label8.Name = "label8";
 		label8.Size = new Size(110, 15);
 		label8.TabIndex = 2;
@@ -351,16 +375,16 @@ partial class KontrahentEdytor
 		tableLayoutPanel1.SetColumnSpan(comboBoxStan, 3);
 		comboBoxStan.DropDownStyle = ComboBoxStyle.DropDownList;
 		comboBoxStan.FormattingEnabled = true;
-		comboBoxStan.Location = new Point(146, 323);
+		comboBoxStan.Location = new Point(146, 352);
 		comboBoxStan.Name = "comboBoxStan";
 		comboBoxStan.Size = new Size(631, 23);
-		comboBoxStan.TabIndex = 11;
+		comboBoxStan.TabIndex = 12;
 		// 
 		// label9
 		// 
 		label9.Anchor = AnchorStyles.Right;
 		label9.AutoSize = true;
-		label9.Location = new Point(110, 327);
+		label9.Location = new Point(110, 356);
 		label9.Name = "label9";
 		label9.Size = new Size(30, 15);
 		label9.TabIndex = 2;
@@ -369,20 +393,20 @@ partial class KontrahentEdytor
 		// checkBoxTP
 		// 
 		checkBoxTP.AutoSize = true;
-		checkBoxTP.Location = new Point(146, 383);
+		checkBoxTP.Location = new Point(146, 412);
 		checkBoxTP.Name = "checkBoxTP";
 		checkBoxTP.Size = new Size(131, 19);
-		checkBoxTP.TabIndex = 14;
+		checkBoxTP.TabIndex = 15;
 		checkBoxTP.Text = "Podmiot powiązany";
 		checkBoxTP.UseVisualStyleBackColor = true;
 		// 
 		// buttonSprawdzMF
 		// 
 		buttonSprawdzMF.AutoSize = true;
-		buttonSprawdzMF.Location = new Point(617, 292);
+		buttonSprawdzMF.Location = new Point(617, 321);
 		buttonSprawdzMF.Name = "buttonSprawdzMF";
 		buttonSprawdzMF.Size = new Size(160, 25);
-		buttonSprawdzMF.TabIndex = 10;
+		buttonSprawdzMF.TabIndex = 11;
 		buttonSprawdzMF.Text = "Sprawdź na białej liście VAT";
 		buttonSprawdzMF.UseVisualStyleBackColor = true;
 		buttonSprawdzMF.Click += buttonSprawdzMF_Click;
@@ -402,7 +426,7 @@ partial class KontrahentEdytor
 		// 
 		labelSposobPlatnosci.Anchor = AnchorStyles.Right;
 		labelSposobPlatnosci.AutoSize = true;
-		labelSposobPlatnosci.Location = new Point(43, 357);
+		labelSposobPlatnosci.Location = new Point(43, 386);
 		labelSposobPlatnosci.Name = "labelSposobPlatnosci";
 		labelSposobPlatnosci.Size = new Size(97, 15);
 		labelSposobPlatnosci.TabIndex = 2;
@@ -414,18 +438,18 @@ partial class KontrahentEdytor
 		tableLayoutPanel1.SetColumnSpan(comboBoxSposobPlatnosci, 2);
 		comboBoxSposobPlatnosci.DropDownStyle = ComboBoxStyle.DropDownList;
 		comboBoxSposobPlatnosci.FormattingEnabled = true;
-		comboBoxSposobPlatnosci.Location = new Point(146, 353);
+		comboBoxSposobPlatnosci.Location = new Point(146, 382);
 		comboBoxSposobPlatnosci.Name = "comboBoxSposobPlatnosci";
 		comboBoxSposobPlatnosci.Size = new Size(465, 23);
-		comboBoxSposobPlatnosci.TabIndex = 12;
+		comboBoxSposobPlatnosci.TabIndex = 13;
 		// 
 		// buttonSposobPlatnosci
 		// 
 		buttonSposobPlatnosci.AutoSize = true;
-		buttonSposobPlatnosci.Location = new Point(617, 352);
+		buttonSposobPlatnosci.Location = new Point(617, 381);
 		buttonSposobPlatnosci.Name = "buttonSposobPlatnosci";
 		buttonSposobPlatnosci.Size = new Size(26, 25);
-		buttonSposobPlatnosci.TabIndex = 13;
+		buttonSposobPlatnosci.TabIndex = 14;
 		buttonSposobPlatnosci.Text = "...";
 		buttonSposobPlatnosci.UseVisualStyleBackColor = true;
 		buttonSposobPlatnosci.Click += buttonSprawdzMF_Click;
@@ -433,7 +457,7 @@ partial class KontrahentEdytor
 		// textBoxNazwaBanku
 		// 
 		textBoxNazwaBanku.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-		textBoxNazwaBanku.Location = new Point(415, 293);
+		textBoxNazwaBanku.Location = new Point(415, 322);
 		textBoxNazwaBanku.Name = "textBoxNazwaBanku";
 		textBoxNazwaBanku.PlaceholderText = "Nazwa banku";
 		textBoxNazwaBanku.Size = new Size(196, 23);
@@ -443,7 +467,7 @@ partial class KontrahentEdytor
 		// 
 		label16.Anchor = AnchorStyles.Right;
 		label16.AutoSize = true;
-		label16.Location = new Point(42, 438);
+		label16.Location = new Point(42, 467);
 		label16.Name = "label16";
 		label16.Size = new Size(98, 15);
 		label16.TabIndex = 14;
@@ -452,7 +476,7 @@ partial class KontrahentEdytor
 		// buttonWaluta
 		// 
 		buttonWaluta.AutoSize = true;
-		buttonWaluta.Location = new Point(415, 433);
+		buttonWaluta.Location = new Point(415, 462);
 		buttonWaluta.Name = "buttonWaluta";
 		buttonWaluta.Size = new Size(26, 25);
 		buttonWaluta.TabIndex = 16;
@@ -464,10 +488,10 @@ partial class KontrahentEdytor
 		comboBoxWaluta.Anchor = AnchorStyles.Left | AnchorStyles.Right;
 		comboBoxWaluta.DropDownStyle = ComboBoxStyle.DropDownList;
 		comboBoxWaluta.FormattingEnabled = true;
-		comboBoxWaluta.Location = new Point(146, 434);
+		comboBoxWaluta.Location = new Point(146, 463);
 		comboBoxWaluta.Name = "comboBoxWaluta";
 		comboBoxWaluta.Size = new Size(263, 23);
-		comboBoxWaluta.TabIndex = 16;
+		comboBoxWaluta.TabIndex = 17;
 		// 
 		// tabPage2
 		// 
@@ -819,10 +843,10 @@ partial class KontrahentEdytor
 		// 
 		checkBoxImportKSeF.AutoSize = true;
 		tableLayoutPanel1.SetColumnSpan(checkBoxImportKSeF, 2);
-		checkBoxImportKSeF.Location = new Point(146, 408);
+		checkBoxImportKSeF.Location = new Point(146, 437);
 		checkBoxImportKSeF.Name = "checkBoxImportKSeF";
 		checkBoxImportKSeF.Size = new Size(343, 19);
-		checkBoxImportKSeF.TabIndex = 15;
+		checkBoxImportKSeF.TabIndex = 16;
 		checkBoxImportKSeF.Text = "Pobrany z KSeF (ukryty przy ręcznym wprowadzaniu faktury)";
 		checkBoxImportKSeF.UseVisualStyleBackColor = true;
 		// 
@@ -870,6 +894,7 @@ partial class KontrahentEdytor
 	private System.Windows.Forms.TextBox textBoxAdresRejestrowy;
 	private System.Windows.Forms.TextBox textBoxAdresKorespondencyjny;
 	private System.Windows.Forms.TextBox textBoxKraj;
+	private System.Windows.Forms.TextBox textBoxKodKraju;
 	private System.Windows.Forms.TextBox textBoxTelefon;
 	private System.Windows.Forms.TextBox textBoxEMail;
 	private System.Windows.Forms.TextBox textBoxRachunekBankowy;
@@ -879,6 +904,7 @@ partial class KontrahentEdytor
 	private System.Windows.Forms.Label label7;
 	private System.Windows.Forms.Label label8;
 	private System.Windows.Forms.Label label17;
+	private System.Windows.Forms.Label label18;
 	private System.Windows.Forms.TextBox textBoxUwagiWewnetrzne;
 	private System.Windows.Forms.ComboBox comboBoxStan;
 	private System.Windows.Forms.Label label9;

--- a/UI/Kontrahenci/KontrahentEdytor.cs
+++ b/UI/Kontrahenci/KontrahentEdytor.cs
@@ -23,6 +23,7 @@ partial class KontrahentEdytor : KontrahentEdytorBase
 		kontroler.Powiazanie(textBoxNIP, kontrahent => kontrahent.NIP);
 		kontroler.Powiazanie(textBoxAdresRejestrowy, kontrahent => kontrahent.AdresRejestrowy);
 		kontroler.Powiazanie(textBoxAdresKorespondencyjny, kontrahent => kontrahent.AdresKorespondencyjny);
+		kontroler.Powiazanie(textBoxKraj, kontrahent => kontrahent.Kraj);
 		kontroler.Powiazanie(textBoxTelefon, kontrahent => kontrahent.Telefon);
 		kontroler.Powiazanie(textBoxEMail, kontrahent => kontrahent.EMail);
 		kontroler.Powiazanie(textBoxRachunekBankowy, kontrahent => kontrahent.RachunekBankowy);

--- a/UI/Kontrahenci/KontrahentEdytor.cs
+++ b/UI/Kontrahenci/KontrahentEdytor.cs
@@ -24,6 +24,7 @@ partial class KontrahentEdytor : KontrahentEdytorBase
 		kontroler.Powiazanie(textBoxAdresRejestrowy, kontrahent => kontrahent.AdresRejestrowy);
 		kontroler.Powiazanie(textBoxAdresKorespondencyjny, kontrahent => kontrahent.AdresKorespondencyjny);
 		kontroler.Powiazanie(textBoxKraj, kontrahent => kontrahent.Kraj);
+		kontroler.Powiazanie(textBoxKodKraju, kontrahent => kontrahent.KodKraju);
 		kontroler.Powiazanie(textBoxTelefon, kontrahent => kontrahent.Telefon);
 		kontroler.Powiazanie(textBoxEMail, kontrahent => kontrahent.EMail);
 		kontroler.Powiazanie(textBoxRachunekBankowy, kontrahent => kontrahent.RachunekBankowy);


### PR DESCRIPTION
 Ten PR dodaje do kontrahenta dwa osobne pola:
  - Kraj
  - Kod kraju

  Zmiana była potrzebna, ponieważ eksport KSeF używał wcześniej stałego kodu kraju `PL` przy generowaniu adresów w  XML. Po tej zmianie kod kraju jest pobierany z danych kontrahenta, a `PL` pozostaje tylko jako bezpieczny fallback.

  Zakres zmian:
  - dodanie pól `Kraj` i `KodKraju` do modelu `Kontrahent`
  - dodanie migracji dla SQLite i SQL Server
  - rozszerzenie edytora kontrahenta o pola `Kraj` i `Kod kraju`
  - ustawianie `Polska` / `PL` przy pobieraniu danych z GUS
  - użycie `KodKraju` w generatorach KSeF `FA_2` i `FA_3`
  - zapisywanie `KodKraju` podczas importu XML KSeF

  Efekt:
  - eksport KSeF nie jest już na sztywno związany z `PL`
  - można poprawnie obsłużyć kontrahentów spoza Polski
  - dane kraju są spójnie utrzymywane w modelu, UI oraz eksporcie/importcie XML
